### PR TITLE
Allow private-file references also in the general part of the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ return your configuration map, but with the snippet dereferenced:
 
 Some configuration probably shouldn't belong in source code control -
 i.e. passwords, credentials, production secrets etc. Nomad allows you
-to define 'private configuration files' - a reference to either host-
+to define 'private configuration files' - a reference to either general, host-,
 or instance-specific files outside of your classpath to include in the
 configuration map.
 
-To do this, include a `:nomad/private-file` key in either your host or
+To do this, include a `:nomad/private-file` key in either your general, host, or
 instance config, pointing to a file on the local file system:
 
 my-config.edn:
@@ -290,7 +290,8 @@ decreasing order of preference):
 * Public instance config
 * Private host config
 * Public host config
-* Other config outside of `:nomad/hosts`
+* Private config outside of `:nomad/hosts`
+* General config outside of `:nomad/hosts`
 
 ### Where does that config value come from?!?!
 

--- a/src/nomad.clj
+++ b/src/nomad.clj
@@ -99,6 +99,7 @@
 
 (defn- merge-configs [configs]
   (-> (deep-merge (or (get-in configs [:general :config]) {})
+                  (or (get-in configs [:general-private :config]) {})
                   (or (get-in configs [:host :config]) {})
                   (or (get-in configs [:host-private :config]) {})
                   (or (get-in configs [:instance :config]) {})
@@ -110,6 +111,7 @@
 (defn- update-config [current-config]
   (-> current-config
       (update-in [:general] update-config-file (get-in current-config [:general :config-file]))
+      (update-private-config :general :general-private)
       (update-specific-config :host :general :nomad/hosts (get-hostname))
       (update-specific-config :instance :host :nomad/instances (get-instance))
       add-environment


### PR DESCRIPTION
This patch enables users of Nomad to use the `private-file` reference also in the general (not host specific) part of the configuration file.

Our use case is to include default values in the configuration file and reference /etc/project-config.edn from there for the host specific part. By doing so, we do not need to know all machines the application might be deployed to in advance (as we would if we used the host-specific functionality of Nomad).

Example:

```
{
 :nomad/private-file #nomad/file "/etc/project.edn"
 :host "http://localhost/"
 :port 80
}
```

Unfortunately, the file (`/etc/project.edn`) must exist and contain at least an empty EDN (`{}`). Maybe offering a `optional-private-file` facility could improve this?
