### PR TITLE
Refactor internals, add read-config function

### DIFF
--- a/src/nomad.clj
+++ b/src/nomad.clj
@@ -5,47 +5,28 @@
             [clojure.tools.reader.edn :as edn]
             [clojure.walk :refer [postwalk-replace]]))
 
-(def ^:dynamic *location-override*)
+;; ## Declarations
 
-(defmacro with-location-override [override & body]
-  `(binding [*location-override* ~override]
-     ~@body))
+(declare safe-slurp)
 
-(defmacro ^:private deflocation [name & body]
-  `(let [get-real-location# (memoize
-                             (fn []
-                               ~@body))]
-     (defn- ~(symbol (str "get-" name)) []
-       (or (get *location-override* (keyword '~name))
-           (get-real-location#)))))
 
-(deflocation hostname
-  (.trim (:out (sh "hostname"))))
+;; ## Vars
 
-(deflocation instance
-  (get (System/getenv) "NOMAD_INSTANCE" :default))
+(def ^:private config-cache
+  (atom {}))
 
-(deflocation environment
-  (or (System/getProperty "nomad.env")
-      (get (System/getenv) "NOMAD_ENV")
-      :default))
+
+;; ## ConfigFile Protocol
 
 (defprotocol ConfigFile
   (etag [_])
   (slurp* [_]))
 
-(defmacro ^:private with-default [default & body]
-  `(or (try
-         ~@body
-         (catch Exception ignore#))
-       ~default))
-
 (extend-protocol ConfigFile
   java.io.File
-  (etag [f] {:file f
+  (etag [f] {:file     f
              :last-mod (.lastModified f)})
-  (slurp* [f] (with-default (pr-str {})
-                (slurp f)))
+  (slurp* [f] (safe-slurp f (pr-str {})))
 
   java.net.URL
   (etag [url]
@@ -55,8 +36,7 @@
       ;; otherwise, we presume the config file is read-only
       ;; (i.e. in a JAR file)
       {:url url}))
-  (slurp* [url] (with-default (pr-str {})
-                  (slurp url)))
+  (slurp* [url] (safe-slurp url (pr-str {})))
 
   nil
   (etag [_] nil)
@@ -66,90 +46,129 @@
   (etag [s] s)
   (slurp* [s] s))
 
-(defn- read-edn-env-var [env-var]
+
+;; ## Private Functions
+
+(defn- get-hostname
+  []
+  (.trim (:out (sh "hostname"))))
+
+(defn- get-instance
+  []
+  (get (System/getenv) "NOMAD_INSTANCE" :default))
+
+(defn- get-environment
+  []
+  (or
+   (System/getProperty "nomad.env")
+   (get (System/getenv) "NOMAD_ENV")
+   :default))
+
+(defn- safe-slurp
+  [f default]
+  (try
+    (slurp f)
+    (catch Exception e
+      default)))
+
+(defn- read-edn-env-var
+  [env-var]
   (let [val-str (System/getenv env-var)]
-    (or (try
-          (edn/read-string val-str)
+    (or
+     (try
+       (edn/read-string val-str)
+       (catch Throwable e
+         (throw (ex-info "Can't read-string edn-env-var:"
+                         {:env-var env-var
+                          :val-str val-str}))))
 
-          (catch Throwable e
-            (throw (ex-info "Can't read-string edn-env-var:"
-                            {:env-var env-var
-                             :val-str val-str}))))
+     ;; This does return :nomad/nil when the env-var is literal
+     ;; nil (i.e. VAR=nil lein repl) but not sure I can fix this
+     ;; until tools.reader accepts nil as a return value from a
+     ;; reader macro fn
+     :nomad/nil)))
 
-        ;; This does return :nomad/nil when the env-var is literal
-        ;; nil (i.e. VAR=nil lein repl) but not sure I can fix this
-        ;; until tools.reader accepts nil as a return value from a
-        ;; reader macro fn
-        :nomad/nil)))
-
-(defn- nomad-data-readers [snippet-reader]
-  {'nomad/file io/file
-   'nomad/snippet snippet-reader
-   'nomad/env-var #(or (System/getenv %) :nomad/nil)
+(defn- nomad-data-readers
+  [snippet-reader]
+  {'nomad/file        io/file
+   'nomad/snippet     snippet-reader
+   'nomad/env-var     #(or (System/getenv %) :nomad/nil)
    'nomad/edn-env-var read-edn-env-var})
 
-(defn- replace-nomad-nils [m]
+(defn- replace-nomad-nils
+  [m]
   (postwalk-replace {:nomad/nil nil} m))
 
-(defn- reload-config-file [config-file]
-  (let [config-str (slurp* config-file)
-        without-snippets (edn/read-string {:readers (nomad-data-readers
-                                                     (constantly ::snippet))}
-                                          config-str)
-        snippets (get without-snippets :nomad/snippets)
-        with-snippets (-> (edn/read-string {:readers (nomad-data-readers
-                                                      (fn [ks]
-                                                        (or (get-in snippets ks)
-                                                            (throw (ex-info "No snippet found for keys" {:keys ks})))))}
-                                           config-str)
-                          (dissoc :nomad/snippets)
-                          replace-nomad-nils)]
-    {:etag (etag config-file)
-     :config-file config-file
-     :config with-snippets}))
+(defn- readers-without-snippets
+  []
+  {:readers (nomad-data-readers (constantly ::snippet))})
 
-(defn- update-config-file [current-config config-file]
+(defn- readers-with-snippets
+  [snippets]
+  {:readers (nomad-data-readers
+             (fn [ks]
+               (or
+                (get-in snippets ks)
+                (throw (ex-info "No snippet found for keys" {:keys ks})))))})
+
+(defn- reload-config-file
+  [config-file]
+  (let [config-str       (slurp* config-file)
+        without-snippets (edn/read-string (readers-without-snippets) config-str)
+        snippets         (get without-snippets :nomad/snippets)
+        with-snippets    (-> (edn/read-string (readers-with-snippets snippets)
+                                              config-str)
+                             (dissoc :nomad/snippets)
+                             replace-nomad-nils)]
+    {:etag        (etag config-file)
+     :config-file config-file
+     :config      with-snippets}))
+
+(defn- update-config-file
+  [current-config config-file]
   (let [{old-etag :etag} current-config
         new-etag (etag config-file)]
     (if (not= old-etag new-etag)
       (reload-config-file config-file)
       current-config)))
 
-(defn- update-specific-config [current-config downstream-key upstream-key selector value]
-  (let [{new-etag :etag
-         new-upstream-config :config} (get current-config upstream-key)
-         
-         {old-etag :upstream-etag
+(defn- update-specific-config
+  [current-config downstream-key upstream-key selector value]
+  (let [{new-etag            :etag
+         new-upstream-config :config}    (get current-config upstream-key)
+
+         {old-etag           :upstream-etag
           old-selector-value :selector-value
           :as current-downstream-config} (get current-config downstream-key)]
     (assoc current-config
       downstream-key (if (and (= new-etag old-etag)
                               (= old-selector-value value))
                        current-downstream-config
-                       {:upstream-etag new-etag
-                        :etag new-etag
+                       {:upstream-etag  new-etag
+                        :etag           new-etag
                         :selector-value value
-                        :config (get-in new-upstream-config [selector value])}))))
+                        :config         (get-in new-upstream-config [selector value])}))))
 
-(defn- add-location [configs]
+(defn- add-location
+  [configs]
   (assoc configs
     :location {:nomad/environment (get-environment)
-               :nomad/hostname (get-hostname)
-               :nomad/instance (get-instance)}))
+               :nomad/hostname    (get-hostname)
+               :nomad/instance    (get-instance)}))
 
-(defn- update-private-config [configs src-key dest-key]
+(defn- update-private-config
+  [configs src-key dest-key]
   (let [{old-public-etag :public-etag
-         :as current-config} (get configs dest-key)
-
-         {new-public-etag :etag} (get configs src-key)
-
-         private-file (get-in configs [src-key :config :nomad/private-file])]
+         :as current-config}    (get configs dest-key)
+        {new-public-etag :etag} (get configs src-key)
+         private-file           (get-in configs [src-key :config :nomad/private-file])]
     (assoc configs
       dest-key (if (not= old-public-etag new-public-etag)
                  (reload-config-file private-file)
                  (update-config-file current-config private-file)))))
 
-(defn- merge-configs [configs]
+(defn- merge-configs
+  [configs]
   (-> (deep-merge (or (get-in configs [:general :config]) {})
                   (or (get-in configs [:general-private :config]) {})
                   (or (get-in configs [:host :config]) {})
@@ -162,7 +181,8 @@
       (dissoc :nomad/hosts :nomad/instances :nomad/environments :nomad/private-file)
       (with-meta configs)))
 
-(defn- update-config [current-config]
+(defn- update-config
+  [current-config]
   (-> current-config
       (update-in [:general] update-config-file (get-in current-config [:general :config-file]))
       (update-specific-config :environment :general :nomad/environments (get-environment))
@@ -174,12 +194,36 @@
       (update-private-config :host :host-private)
       (update-private-config :instance :instance-private)))
 
-(defn- get-current-config [config-ref]
-  (dosync
-   (-> (alter config-ref update-config)
-       merge-configs)))
+(defn- cache-config!
+  [cache-key config]
+  (swap! config-cache assoc cache-key config))
 
-(defmacro defconfig [name file-or-resource]
-  `(let [config-ref# (ref {:general {:config-file ~file-or-resource}})]
-     (defn ~name []
-       (#'get-current-config config-ref#))))
+(defn- get-current-config
+  [file-or-resource]
+  (let [config-map     {:general {:config-file file-or-resource}}
+        updated-config (update-config config-map)]
+    (cache-config! file-or-resource updated-config)
+    (merge-configs updated-config)))
+
+
+;; ## Macros
+
+(defmacro with-location-override
+  [override & body]
+  (let [[override-type override-value] (first override)
+        override-fn-name               (str "nomad/get-" (name override-type))
+        override-fn-sym                (symbol override-fn-name)]
+    `(with-redefs [~override-fn-sym (constantly ~override-value)]
+       ~@body)))
+
+(defmacro defconfig
+  [name file-or-resource]
+  `(defn ~name []
+    (#'get-current-config ~file-or-resource)))
+
+
+;; ## Public Config Functions
+
+(defn read-config
+  [file-or-resource]
+  (get-current-config file-or-resource))


### PR DESCRIPTION
As per the discussion in #10, I've added a function called `(read-config ...)` which takes a file path string or resource object. I've also refactored some of the internals to be a bit more idiomatic:
- Removed unnecessary macros. They weren't bad, but I like to adhere to the [first rule of macro club](http://clojurefun.wordpress.com/2013/01/09/when-do-you-need-macros-in-clojure/). Without those macros, there are no more magic functions defined in the namespace, fewer refs which means less mutable state, and I think the `(with-location-override ...)` macro is more threadsafe since it's now using with-redefs which updates the bindings for all threads.
- The only state remaining is contained in the `config-cache` atom which holds a hash map. The map is keyed by the file-or-resource used to init the config, and maps to the current config data. All of the current cache/update semantics are preserved, as far as I can tell.
- Some minor reorganization and formatting changes.

All of the current test suite passes cleanly. If you like, I can add a test for the `(read-config ...)` function, but since it just passes through to the already well-tested `(get-current-config ...)` functionality, it seemed reasonable to omit.

Let me know if you have any questions/comments. Cheers!
