### PR TITLE
Add support for environment variables with default values

### DIFF
--- a/README.org
+++ b/README.org
@@ -394,6 +394,39 @@ Reading the port from the config:
   ;; -> java.lang.Long
 #+END_SRC
 
+**** With defaults
+
+Both the =#nomad/env-var= and =#nomad/edn-env-var= reader macros also
+support a vector, of the form =["PORT" 3000]=. If the environment
+variable named by the first element of the vector is not present, the
+second element of the vector will be used as a default.
+
+In config:
+
+#+BEGIN_SRC clojure
+  {:port #nomad/edn-env-var ["PORT" 3000]}
+#+END_SRC
+
+When the =PORT= environment variable is unset
+
+#+BEGIN_SRC clojure
+  (defconfig config (...))
+  
+  (:port (config)) 
+  ;; -> 3000
+#+END_SRC
+
+When it's set:
+
+#+BEGIN_SRC sh
+  PORT=5000 lein repl
+#+END_SRC
+
+#+BEGIN_SRC clojure
+  (:port (config))
+  ;; -> 5000
+#+END_SRC
+
 ** Order of preference
 
 Nomad now merges all of your public/private/host/instance

--- a/src/nomad.clj
+++ b/src/nomad.clj
@@ -50,27 +50,32 @@
       (get (System/getenv) "NOMAD_ENV")
       :default))
 
-(defn- read-edn-env-var [env-var]
-  (let [val-str (System/getenv env-var)]
+(defn- extract-config [config]
+  (if (vector? config)
+    config
+    ;; This does return :nomad/nil when the env-var is literal
+    ;; nil (i.e. VAR=nil lein repl) but not sure I can fix this
+    ;; until tools.reader accepts nil as a return value from a
+    ;; reader macro fn
+    [config :nomad/nil]))
+
+(defn- read-env-var [config]
+  (let [[env-var default] (extract-config config)]
+    (or (System/getenv env-var) default)))
+
+(defn- read-edn-env-var [config]
+  (let [[env-var default] (extract-config config)
+        val-str (System/getenv env-var)]
     (or
      (try
        (edn/read-string val-str)
        (catch Throwable e
          (throw (ex-info "Can't read-string edn-env-var:"
-                         {:env-var env-var
+                         {:env-var (config 0)
+                          :default (config 1)
                           :val-str val-str}))))
 
-     ;; This does return :nomad/nil when the env-var is literal
-     ;; nil (i.e. VAR=nil lein repl) but not sure I can fix this
-     ;; until tools.reader accepts nil as a return value from a
-     ;; reader macro fn
-     :nomad/nil)))
-
-(defn read-env-var [config]
-  (let [[env-var default] (if (vector? config)
-                            config
-                            [config :nomad/nil])]
-    (or (System/getenv env-var) default)))
+     default)))
 
 (defn- nomad-data-readers [snippet-reader]
   {'nomad/file io/file

--- a/src/nomad.clj
+++ b/src/nomad.clj
@@ -66,10 +66,16 @@
      ;; reader macro fn
      :nomad/nil)))
 
+(defn read-env-var [config]
+  (let [[env-var default] (if (vector? config)
+                            config
+                            [config :nomad/nil])]
+    (or (System/getenv env-var) default)))
+
 (defn- nomad-data-readers [snippet-reader]
   {'nomad/file io/file
    'nomad/snippet snippet-reader
-   'nomad/env-var #(or (System/getenv %) :nomad/nil)
+   'nomad/env-var read-env-var
    'nomad/edn-env-var read-edn-env-var})
 
 (defn- replace-nomad-nils [m]

--- a/test/nomad_test.clj
+++ b/test/nomad_test.clj
@@ -135,6 +135,14 @@
                                      (constantly "{:test #nomad/env-var [\"NOPE\" :default]}")))]
     (test/is (= :default (:test config)))))
 
+(deftest loads-default-edn-env-vars
+  (let [{:keys [etag config]}
+        (#'nomad/update-config-file {}
+                                    (DummyConfigFile.
+                                     (constantly :etag)
+                                     (constantly "{:test #nomad/edn-env-var [\"NOPE\" :default]}")))]
+    (test/is (= :default (:test config)))))
+
 (defrecord DummyPrivateFile [etag* content*]
   nomad/ConfigFile
   (etag [_] etag*)

--- a/test/nomad_test.clj
+++ b/test/nomad_test.clj
@@ -127,6 +127,14 @@
                                                     (constantly (pr-str {})))}}))]
     (test/is (= "dummy-instance" (get-in returned-config [:location :nomad/instance])))))
 
+(deftest loads-default-env-vars
+  (let [{:keys [etag config]}
+        (#'nomad/update-config-file {}
+                                    (DummyConfigFile.
+                                     (constantly :etag)
+                                     (constantly "{:test #nomad/env-var [\"NOPE\" :default]}")))]
+    (test/is (= :default (:test config)))))
+
 (defrecord DummyPrivateFile [etag* content*]
   nomad/ConfigFile
   (etag [_] etag*)


### PR DESCRIPTION
Support both of:

- `#nomad/env-var ["ENV_VAR" :default]`
- `#nomad/edn-env-var ["ENV_VAR" :default]`

Fixes #20