### PR TITLE
Fixes a document of `deep-merge` and refactors its implement 

### DIFF
--- a/src/nomad/map.clj
+++ b/src/nomad/map.clj
@@ -7,9 +7,6 @@
               {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
   -> {:a {:b {:c 2, :d {:x 1, :y 2, :z 9}, :z 3}, :e 100}, :f 4}"
   [& maps]
-  (apply
-    (fn m [& maps]
-      (if (every? map? maps)
-        (apply merge-with m maps)
-        (last maps)))
-    maps))
+  (if (every? map? maps)
+    (apply merge-with deep-merge maps)
+    (last maps)))

--- a/src/nomad/map.clj
+++ b/src/nomad/map.clj
@@ -1,12 +1,11 @@
 (ns nomad.map)
 
 (defn deep-merge
-  "Like merge-with, but merges maps recursively, applying the given fn
-  only when there's a non-map at a particular level.
- 
-  (deep-merge + {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
-               {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
-  -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
+  "Like merge, but merges maps recursively.
+
+  (deep-merge {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
+              {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
+  -> {:a {:b {:c 2, :d {:x 1, :y 2, :z 9}, :z 3}, :e 100}, :f 4}"
   [& maps]
   (apply
     (fn m [& maps]

--- a/test/nomad/map_test.clj
+++ b/test/nomad/map_test.clj
@@ -1,0 +1,9 @@
+(ns nomad.map-test
+  (:require [nomad.map :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest deep-merge-test
+  (let [v1 {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
+        v2 {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}}]
+    (is (= {:a {:b {:c 2, :d {:x 1, :y 2, :z 9}, :z 3}, :e 100}, :f 4}
+           (deep-merge v1 v2)))))


### PR DESCRIPTION
This patch fixes a document of `deep-merge` and refactors its implement .

I noticed that a document of `deep-merge` doesn't  represent of its behavior.
So, I fixed the document.
And I refactored an implement  of `deep-merge`, because it uses useless `apply` .