### PR TITLE
Update docs for env-var signature change

### DIFF
--- a/README.org
+++ b/README.org
@@ -345,7 +345,12 @@ as environment variables.
 In config:
 
 #+BEGIN_SRC clojure
-  {:db-password #nomad/env-var "DB_PASSWORD"}
+  {:db-password #nomad/env-var ["DB_PASSWORD"]}
+#+END_SRC
+
+Default values can be provided as the second element in the vector:
+#+BEGIN_SRC clojure
+  {:host #nomad/env-var ["DB_PASSWORD" "default-value"]}
 #+END_SRC
 
 Starting up:


### PR DESCRIPTION
The signature of env-var has changed as it now takes a vector to allow a default arg. This updates the docs